### PR TITLE
Add theme base16-tomorrow

### DIFF
--- a/themes/base16-tomorrow
+++ b/themes/base16-tomorrow
@@ -1,0 +1,63 @@
+# vim: filetype=yaml
+---
+colors:
+    base00:              '#1d1f21'
+    base01:              '#282a2e'
+    base02:              '#373b41'
+    base03:              '#969896'
+    base04:              '#b4b7b4'
+    base05:              '#c5c8c6'
+    base06:              '#e0e0e0'
+    base07:              '#ffffff'
+    base08:              '#cc6666'
+    base09:              '#de935f'
+    base0A:              '#f0c674'
+    base0B:              '#b5bd68'
+    base0C:              '#8abeb7'
+    base0D:              '#81a2be'
+    base0E:              '#b294bb'
+    base0F:              '#a3685a'
+
+meta:
+    description:         'Base16 Tomorrow, by Chris Kempson (http://chriskempson.com)'
+window_colors:
+    focused:
+        border:          'base0D'
+        background:      'base0D'
+        text:            'base00'
+        indicator:       'base01'
+    focused_inactive:
+        border:          'base02'
+        background:      'base02'
+        text:            'base03'
+        indicator:       'base01'
+    unfocused:
+        border:          'base01'
+        background:      'base01'
+        text:            'base03'
+        indicator:       'base01'
+    urgent:
+        border:          'base02'
+        background:      'base08'
+        text:            'base07'
+        indicator:       'base08'
+bar_colors:
+    separator:           'base03'
+    background:          'base00'
+    statusline:          'base05'
+    focused_workspace:
+        border:          'base0D'
+        background:      'base0D'
+        text:            'base00'
+    active_workspace:
+        border:          'base02'
+        background:      'base02'
+        text:            'base07'
+    inactive_workspace:
+        border:          'base01'
+        background:      'base01'
+        text:            'base03'
+    urgent_workspace:
+        border:          'base08'
+        background:      'base08'
+        text:            'base07'


### PR DESCRIPTION
Chris Kempson created the tomorrow theme, including the variant
'Tomorrow Night 80s', which was very popular, and already in this theme
pack. The theme evolved into the base16 project, which condenses the
number of colours down to a minimalistic 16. This i3-status theme is
using said colour scheme.

Though similar to the tomorrow-night-80s theme, this focuses on blue,
rather than green. This can be altered to the green by changing
    base0D ==> base0B
in the window and bar sections before applying.

It is also suggested to add:
    colors = true
    color_good = "#b5bd68"  # base0B
    color_bad = "#cc6666"  # base08
to the general section of your i3status.conf file to use the more mellow
green and reds from this theme.